### PR TITLE
Update how cmd specified

### DIFF
--- a/PyCmdMessenger/PyCmdMessenger.py
+++ b/PyCmdMessenger/PyCmdMessenger.py
@@ -70,9 +70,11 @@ class CmdMessenger:
         self.give_warnings = warnings
 
         self._cmd_name_to_int = {}
+        self._int_to_cmd_name = {}
         self._cmd_name_to_format = {}
         for i, c in enumerate(commands):
             self._cmd_name_to_int[c[0]] = i
+            self._int_to_cmd_name[i] = c[0]
             self._cmd_name_to_format[c[0]] = c[1]
  
         self._byte_field_sep = self.field_separator.encode("ascii")
@@ -237,7 +239,7 @@ class CmdMessenger:
         # Get the command name.
         cmd = fields[0].strip().decode()
         try:
-            cmd_name = self.command_names[int(cmd)]
+            cmd_name = self._int_to_cmd_name[int(cmd)]
         except (ValueError,IndexError):
 
             if self.give_warnings:

--- a/PyCmdMessenger/PyCmdMessenger.py
+++ b/PyCmdMessenger/PyCmdMessenger.py
@@ -21,8 +21,7 @@ class CmdMessenger:
     
     def __init__(self,
                  board_instance,
-                 command_names,
-                 command_formats=None,
+                 commands,
                  field_separator=",",
                  command_separator=";",
                  escape_separator="/",
@@ -34,14 +33,12 @@ class CmdMessenger:
                 connection (points to correct serial with correct baud rate) and
                 correct board parameters (float bytes, etc.)
 
-            command_names:
-                a list or tuple of the command names specified in the arduino
-                .ino file *in the same order they are listed there.*  
-
-            command_formats:
-                a list or tuple of strings that specify the formats of the
-                commands in command names.  Optional but *highly* recommmended.
-                Default: None
+            commands:
+                a list or tuple of commands specified in the arduino .ino file
+                *in the same order* they are listed there.  commands should be
+                a list of lists, where the first element in the list specifies
+                the command name and the second the formats for the arguments.
+                (e.g. commands = [["who_are_you",""],["my_name_is","s"]])
 
             field_separator:
                 character that separates fields within a message
@@ -66,24 +63,17 @@ class CmdMessenger:
 
         self.board = board_instance
 
-        self.command_names = command_names[:]
-        self._cmd_name_to_int = dict([(n,i) for i,n in enumerate(self.command_names)])
-
-        self.command_formats = command_formats
-        self._cmd_name_to_format = {}
-        if self.command_formats != None:
-            if len(self.command_formats) != len(self.command_names):
-                err = "You must specify the same number of command formats and command names."
-                raise ValueError(err)
-
-            for i in range(len(self.command_names)):
-                self._cmd_name_to_format[self.command_names[i]] = self.command_formats[i]
-
+        self.commands = commands[:]
         self.field_separator = field_separator
         self.command_separator = command_separator
         self.escape_separator = escape_separator
-  
         self.give_warnings = warnings
+
+        self._cmd_name_to_int = {}
+        self._cmd_name_to_format = {}
+        for i, c in enumerate(commands):
+            self._cmd_name_to_int[c[0]] = i
+            self._cmd_name_to_format[c[0]] = c[1]
  
         self._byte_field_sep = self.field_separator.encode("ascii")
         self._byte_command_sep = self.command_separator.encode("ascii")
@@ -126,11 +116,9 @@ class CmdMessenger:
         arduino using the CmdMessage protocol.  The command and any parameters
         should be passed as direct arguments to send.  
 
-        arg_formats optional, but highly recommended if you do not initialize
-        the class instance with a command_formats argument.  The keyword  
-        specifies the formats to use for each argument when passed to the
-        arduino. If specified here, arg_formats supercedes command_formats
-        specified on initialization.  
+        arg_formats is an optional string that specifies the formats to use for
+        each argument when passed to the arduino. If specified here,
+        arg_formats supercedes formats specified on initialization.  
         """
 
         # Turn the command into an integer.
@@ -178,10 +166,9 @@ class CmdMessenger:
         """
         Recieve commands coming off the serial port. 
 
-        arg_formats optional, but highly recommended if you do not initialize
-        the class instance with a command_formats argument.  The keyword  
-        specifies the formats to use to parse incoming arguments.  If specified
-        here, arg_formats supercedes command_formats specified on initialization.  
+        arg_formats is an optimal keyword that specifies the formats to use to
+        parse incoming arguments.  If specified here, arg_formats supercedes
+        the formats specified on initialization.  
         """
 
         # Read serial input until a command separator or empty character is
@@ -206,7 +193,6 @@ class CmdMessenger:
                     msg[-1].append(self._byte_escape_sep)
                     msg[-1].append(tmp)
                     escaped = False
-
             else:
 
                 # look for escape character
@@ -310,7 +296,6 @@ class CmdMessenger:
             raise OverflowError(err)
 
         return struct.pack('c',value)
-
 
     def _send_int(self,value):
         """

--- a/README.md
+++ b/README.md
@@ -155,18 +155,16 @@ import PyCmdMessenger
 # to set the data sizes (bytes for integers, longs, floats, and doubles).  
 arduino = PyCmdMessenger.ArduinoBoard("/dev/ttyACM0",baud_rate=9600)
 
-# List of command_names in arduino file. These must be in the same order as in
-# the sketch.
-command_names = ["who_are_you","my_name_is","sum_two_ints","sum_is","error"]
-
-# List of data types being sent/recieved for each command, again in the same 
-# order. 
-command_formats = ["","s","ii","i","s"]
+# List of command names (and formats for their associated arguments). These must
+# be in the same order as in the sketch.
+commands = [["who_are_you",""],
+            ["my_name_is","s"],
+            ["sum_two_ints","ii"],
+            ["sum_is","i"],
+            ["error","s"]]
 
 # Initialize the messenger
-c = PyCmdMessenger.CmdMessenger(arduino,
-                                command_names=command_names,
-                                command_formats=command_formats)
+c = PyCmdMessenger.CmdMessenger(arduino,commands)
 
 # Send
 c.send("who_are_you")
@@ -288,83 +286,6 @@ c.sendCmdEnd();
 ##Python Classes
 
 ```
-CmdMessenger 
-    Basic interface for interfacing over a serial connection to an arduino 
-    using the CmdMessenger library.
-
-    Static methods
-    --------------
-    __init__(self, board_instance, command_names, command_formats=None, field_separator=',', command_separator=';', escape_separator='/', warnings=True)
-        Input:
-        board_instance:
-            instance of ArduinoBoard initialized with correct serial 
-            connection (points to correct serial with correct baud rate) and
-            correct board parameters (float bytes, etc.)
-
-        command_names:
-            a list or tuple of the command names specified in the arduino
-            .ino file *in the same order they are listed there.*  
-
-        command_formats:
-            a list or tuple of strings that specify the formats of the
-            commands in command names.  Optional but *highly* recommmended.
-            Default: None
-
-        field_separator:
-            character that separates fields within a message
-            Default: ","
-
-        command_separator:
-            character that separates messages (commands) from each other
-            Default: ";" 
-
-        escape_separator:
-            escape character to allow separators within messages.
-            Default: "/"
-
-        warnings:
-            warnings for user
-            Default: True
-
-        The separators and escape_separator should match what's
-        in the arduino code that initializes the CmdMessenger.  The default
-        separator values match the default values as of CmdMessenger 4.0.
-
-    receive(self, arg_formats=None)
-        Recieve commands coming off the serial port. 
-
-        arg_formats optional, but highly recommended if you do not initialize
-        the class instance with a command_formats argument.  The keyword  
-        specifies the formats to use to parse incoming arguments.  If specified
-        here, arg_formats supercedes command_formats specified on initialization.
-
-    send(self, cmd, *args)
-        Send a command (which may or may not have associated arguments) to an 
-        arduino using the CmdMessage protocol.  The command and any parameters
-        should be passed as direct arguments to send.  
-
-        arg_formats optional, but highly recommended if you do not initialize
-        the class instance with a command_formats argument.  The keyword  
-        specifies the formats to use for each argument when passed to the
-        arduino. If specified here, arg_formats supercedes command_formats
-        specified on initialization.
-
-    Instance variables
-    ------------------
-    board
-
-    command_formats
-
-    command_names
-
-    command_separator
-
-    escape_separator
-
-    field_separator
-
-    give_warnings
-
 ArduinoBoard 
     Class for connecting to an Arduino board over USB using PyCmdMessenger.  
     The board holds the serial handle (which, in turn, holds the device name,
@@ -439,4 +360,74 @@ ArduinoBoard
     unsigned_long_max
 
     unsigned_long_min
+
+CmdMessenger 
+    Basic interface for interfacing over a serial connection to an arduino 
+    using the CmdMessenger library.
+
+    Static methods
+    --------------
+    __init__(self, board_instance, commands, field_separator=',', command_separator=';', escape_separator='/', warnings=True)
+        Input:
+        board_instance:
+            instance of ArduinoBoard initialized with correct serial 
+            connection (points to correct serial with correct baud rate) and
+            correct board parameters (float bytes, etc.)
+
+        commands:
+            a list or tuple of commands specified in the arduino .ino file
+            *in the same order* they are listed there.  commands should be
+            a list of lists, where the first element in the list specifies
+            the command name and the second the formats for the arguments.
+            (e.g. commands = [["who_are_you",""],["my_name_is","s"]])
+
+        field_separator:
+            character that separates fields within a message
+            Default: ","
+
+        command_separator:
+            character that separates messages (commands) from each other
+            Default: ";" 
+
+        escape_separator:
+            escape character to allow separators within messages.
+            Default: "/"
+
+        warnings:
+            warnings for user
+            Default: True
+
+        The separators and escape_separator should match what's
+        in the arduino code that initializes the CmdMessenger.  The default
+        separator values match the default values as of CmdMessenger 4.0.
+
+    receive(self, arg_formats=None)
+        Recieve commands coming off the serial port. 
+
+        arg_formats is an optimal keyword that specifies the formats to use to
+        parse incoming arguments.  If specified here, arg_formats supercedes
+        the formats specified on initialization.
+
+    send(self, cmd, *args)
+        Send a command (which may or may not have associated arguments) to an 
+        arduino using the CmdMessage protocol.  The command and any parameters
+        should be passed as direct arguments to send.  
+
+        arg_formats is an optional string that specifies the formats to use for
+        each argument when passed to the arduino. If specified here,
+        arg_formats supercedes formats specified on initialization.
+
+    Instance variables
+    ------------------
+    board
+
+    command_separator
+
+    commands
+
+    escape_separator
+
+    field_separator
+
+    give_warnings
 ```

--- a/examples/python-basic.py
+++ b/examples/python-basic.py
@@ -9,18 +9,16 @@ import PyCmdMessenger
 # to set the data sizes (bytes for integers, longs, floats, and doubles).  
 arduino = PyCmdMessenger.ArduinoBoard("/dev/ttyACM0",baud_rate=9600)
 
-# List of command_names in arduino file. These must be in the same order as in
-# the sketch.
-command_names = ["who_are_you","my_name_is","sum_two_ints","sum_is","error"]
-
-# List of data types being sent/recieved for each command, again in the same 
-# order. 
-command_formats = ["","s","ii","i","s"]
+# List of commands and their associated argument formats. These must be in the
+# same order as in the sketch.
+commands = [["who_are_you",""],
+            ["my_name_is","s"],
+            ["sum_two_ints","ii"],
+            ["sum_is","i"],
+            ["error","s"]]
 
 # Initialize the messenger
-c = PyCmdMessenger.CmdMessenger(arduino,
-                                command_names=command_names,
-                                command_formats=command_formats)
+c = PyCmdMessenger.CmdMessenger(arduino,commands)
 
 # Send
 c.send("who_are_you")

--- a/test/pingpong_test.py
+++ b/test/pingpong_test.py
@@ -14,7 +14,7 @@ BAUD_RATE = 115200
 
 COMMANDS = [["kCommError",""],
             ["kComment",""],
-            ["kAcknowledge",""],
+            ["kAcknowledge","s"],
             ["kAreYouReady","si"],
             ["kError","s"],
             ["kAskUsIfReady","s"],

--- a/test/pingpong_test.py
+++ b/test/pingpong_test.py
@@ -12,25 +12,25 @@ import time, string, sys, struct, random
 
 BAUD_RATE = 115200
 
-COMMAND_NAMES = ["kCommError",
-                 "kComment",
-                 "kAcknowledge",
-                 "kAreYouReady",
-                 "kError",
-                 "kAskUsIfReady",
-                 "kYouAreReady",
-                 "kValuePing",
-                 "kValuePong",
-                 "kMultiValuePing",
-                 "kMultiValuePong",
-                 "kRequestReset",
-                 "kRequestResetAcknowledge",
-                 "kRequestSeries",
-                 "kReceiveSeries",
-                 "kDoneReceiveSeries",
-                 "kPrepareSendSeries",
-                 "kSendSeries",
-                 "kAckSendSeries"]
+COMMANDS = [["kCommError",""],
+            ["kComment",""],
+            ["kAcknowledge",""],
+            ["kAreYouReady","si"],
+            ["kError","s"],
+            ["kAskUsIfReady","s"],
+            ["kYouAreReady","s"],
+            ["kValuePing","gg"],
+            ["kValuePong","g"],
+            ["kMultiValuePing","ild"],
+            ["kMultiValuePong","ild"],
+            ["kRequestReset",""],
+            ["kRequestResetAcknowledge",""],
+            ["kRequestSeries","if"],
+            ["kReceiveSeries",""],
+            ["kDoneReceiveSeries",""],
+            ["kPrepareSendSeries",""],
+            ["kSendSeries",""],
+            ["kAckSendSeries",""]]
 
 TYPE_LIST = ["kBool",
              "kInt16",
@@ -244,7 +244,7 @@ class PingPong:
     
         self.type_name = type_name
         self.connection = PyCmdMessenger.CmdMessenger(board_instance=board,
-                                                      command_names=COMMAND_NAMES,
+                                                      commands=COMMANDS,
                                                       warnings=False)
         self.test_class = test_class
         self.command = command

--- a/test/rapid-float_test.py
+++ b/test/rapid-float_test.py
@@ -26,7 +26,8 @@ def main(argv=None):
         raise IndexError(err)
 
     a = PyCmdMessenger.ArduinoBoard(serial_device,115200)
-    c = PyCmdMessenger.CmdMessenger(a,["double_ping","double_pong"],["d","d"])
+    c = PyCmdMessenger.CmdMessenger(a,[["double_ping","d"],
+                                       ["double_pong","d"]])
 
     for i in range(10000):
 


### PR DESCRIPTION
Altered class initialization so it takes a list of lists specifying commands and argument formats.  This is much saner than two lists which could (for example) have elements flipped.  It also now forces the user to specify formats.   