### PR TITLE
Add dtr flag

### DIFF
--- a/PyCmdMessenger/arduino.py
+++ b/PyCmdMessenger/arduino.py
@@ -21,7 +21,7 @@ class ArduinoBoard:
                  baud_rate=9600,
                  timeout=1.0,
                  settle_time=2.0,
-                 disable_dtr=True,
+                 enable_dtr=False,
                  int_bytes=2,
                  long_bytes=4,
                  float_bytes=4,
@@ -34,7 +34,7 @@ class ArduinoBoard:
             baud_rate: baud rate set in the compiled sketch
             timeout: timeout for serial reading and writing
             settle_time: how long to wait before trying to access serial port
-            disable_dtr: disable DTR (preventing reset on opening connection)
+            enable_dtr: use DTR (set to False to prevent arduino reset on connect)
 
         Board input parameters:
             int_bytes: number of bytes to store an integer
@@ -52,7 +52,7 @@ class ArduinoBoard:
         self.baud_rate = baud_rate
         self.timeout = timeout
         self.settle_time = settle_time
-        self.dtr_setting = not disable_dtr
+        self.enable_dtr = enable_dtr
 
         self.int_bytes = int_bytes
         self.long_bytes = long_bytes
@@ -152,10 +152,10 @@ class ArduinoBoard:
             print("Connecting to arduino on {}... ".format(self.device),end="")
 
             self.comm = serial.Serial()
-            self.comm.device = self.device
-            self.comm.baud_rate = self.baud_rate
+            self.comm.port = self.device
+            self.comm.baudrate = self.baud_rate
             self.comm.timeout = self.timeout
-            self.comm.setDTR(self.dtr_setting)
+            self.dtr = self.enable_dtr
             self.comm.open()
 
             time.sleep(self.settle_time)

--- a/PyCmdMessenger/arduino.py
+++ b/PyCmdMessenger/arduino.py
@@ -153,8 +153,8 @@ class ArduinoBoard:
 
             self.comm = serial.Serial()
             self.comm.device = self.device
-            self.comm.baud_rate = baud_rate
-            self.comm.timeout = timeout
+            self.comm.baud_rate = self.baud_rate
+            self.comm.timeout = self.timeout
             self.comm.setDTR(self.dtr_setting)
             self.comm.open()
 

--- a/PyCmdMessenger/arduino.py
+++ b/PyCmdMessenger/arduino.py
@@ -21,6 +21,7 @@ class ArduinoBoard:
                  baud_rate=9600,
                  timeout=1.0,
                  settle_time=2.0,
+                 disable_dtr=True,
                  int_bytes=2,
                  long_bytes=4,
                  float_bytes=4,
@@ -33,6 +34,7 @@ class ArduinoBoard:
             baud_rate: baud rate set in the compiled sketch
             timeout: timeout for serial reading and writing
             settle_time: how long to wait before trying to access serial port
+            disable_dtr: disable DTR (preventing reset on opening connection)
 
         Board input parameters:
             int_bytes: number of bytes to store an integer
@@ -50,6 +52,7 @@ class ArduinoBoard:
         self.baud_rate = baud_rate
         self.timeout = timeout
         self.settle_time = settle_time
+        self.dtr_setting = not disable_dtr
 
         self.int_bytes = int_bytes
         self.long_bytes = long_bytes
@@ -147,10 +150,13 @@ class ArduinoBoard:
         if not self._is_connected:
             
             print("Connecting to arduino on {}... ".format(self.device),end="")
-            self.comm = serial.Serial(self.device,
-                                      self.baud_rate,
-                                      timeout=self.timeout)
-        
+
+            self.comm = serial.Serial()
+            self.comm.device = self.device
+            self.comm.baud_rate = baud_rate
+            self.comm.timeout = timeout
+            self.comm.setDTR(self.dtr_setting)
+            self.comm.open()
 
             time.sleep(self.settle_time)
             self._is_connected = True

--- a/PyCmdMessenger/arduino.py
+++ b/PyCmdMessenger/arduino.py
@@ -95,7 +95,7 @@ class ArduinoBoard:
         if self.double_bytes == 4: 
             self.double_min = -3.4028235E+38
             self.double_max =  3.4028235E+38
-        elif self.double_byes == 8:
+        elif self.double_bytes == 8:
             self.double_min = -1e308
             self.double_max =  1e308
         else:

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ To test the library:
    types between the local computer and the arduino.  
 
 ### Compatibility
- * Compatibility: 3.x
+ * Compatibility: Python 3.x
  * Should work on all platforms supported by pyserial.  
- * Tested on a Raspberry Pi (raspbian) and linux machine (Ununtu 15.10).  Have 
-not tested on Windows or OSX, but it should work fine.
+ * Known to work on Raspberry Pi (raspbian), linux (Ubuntu 15.10), and Windows 10. 
 
 ### Dependencies
  * pyserial (on local machine): https://github.com/pyserial/pyserial
@@ -237,7 +236,7 @@ reporting success and failure.
 
 ##Known Issues
 
- + Opening the serial connection from a linux machine will cause the arduino to reset.  This is a [known issue](https://github.com/pyserial/pyserial/issues/124) with PySerial.  This behavior can be prevented from a windows host using by setting `ardino.ArduinoBoard(enable_dtr=False)` (the default).  
+ + Opening the serial connection from a linux machine will cause the arduino to reset.  This is a [known issue](https://github.com/pyserial/pyserial/issues/124) with pyserial and the arudino architecture.  This behavior can be prevented on a windows host using by setting `arduino.ArduinoBoard(enable_dtr=False)` (the default). See [issue #9](https://github.com/harmsm/PyCmdMessenger/issues/9) for discussion.  
 
 ##Quick reference for CmdMessenger on arduino side
 For more details, see the [CmdMessenger](https://github.com/thijse/Arduino-CmdMessenger) project page.
@@ -294,13 +293,14 @@ ArduinoBoard
 
     Static methods
     --------------
-    __init__(self, device, baud_rate=9600, timeout=1.0, settle_time=2.0, int_bytes=2, long_bytes=4, float_bytes=4, double_bytes=4)
+    __init__(self, device, baud_rate=9600, timeout=1.0, settle_time=2.0, enable_dtr=False, int_bytes=2, long_bytes=4, float_bytes=4, double_bytes=4)
         Serial connection parameters:
             
             device: serial device (e.g. /dev/ttyACM0)
             baud_rate: baud rate set in the compiled sketch
             timeout: timeout for serial reading and writing
             settle_time: how long to wait before trying to access serial port
+            enable_dtr: use DTR (set to False to prevent arduino reset on connect)
 
         Board input parameters:
             int_bytes: number of bytes to store an integer

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ onto an arudino, as well as a python test script, `pingpong_test.py`.  This will
 send a wide range of values for every data type back and forth to the arduino,
 reporting success and failure.  
 
+##Known Issues
+
+ + Opening the serial connection from a linux machine will cause the arduino to reset.  This is a [known issue](https://github.com/pyserial/pyserial/issues/124) with PySerial.  This behavior can be prevented from a windows host using by setting `ardino.ArduinoBoard(enable_dtr=False)` (the default).  
+
 ##Quick reference for CmdMessenger on arduino side
 For more details, see the [CmdMessenger](https://github.com/thijse/Arduino-CmdMessenger) project page.
 

--- a/test/pingpong_arduino/main.cpp
+++ b/test/pingpong_arduino/main.cpp
@@ -323,6 +323,17 @@ void toggleLed()
 void setup() 
 {
   // Listen on serial connection for messages from the pc
+
+
+  pinMode(5,OUTPUT);
+  // Start by blinking LED for 1 s
+  pinMode(LED_BUILTIN,OUTPUT);
+  for (int i = 0; i < 5; i++){
+    digitalWrite(LED_BUILTIN,HIGH);
+    delay(50*i);
+    digitalWrite(LED_BUILTIN,LOW);
+    delay(50*i);
+  }
   
   // 115200 is the max speed on Arduino Uno, Mega, with AT8u2 USB
   // SERIAL_8N1 is the default config, but we want to make certain
@@ -362,6 +373,7 @@ bool hasExpired(unsigned long &prevTime, unsigned long interval) {
 
 void loop() 
 {
+  analogWrite(5,255); //pwm_value);
   // Process incoming serial data, and perform callbacks
   cmdMessenger.feedinSerialData();
 
@@ -369,7 +381,7 @@ void loop()
   // this means the callbacks my the Messenger are taking a longer time than that  
   if (hasExpired(previousToggleLed,2000)) // Every 2 secs
   {
-    toggleLed();  
+    //toggleLed();  
   } 
 }
 


### PR DESCRIPTION
Added ability to enable or disable DTR when opening a pyserial connection.  With DTR enabled, the arduino resets when the connection opens.  With DTR disabled, the arduino should not reset.  Unfortunately, this is only true for Windows.  Using linux, the arduino will always reset.   (See [here](https://github.com/harmsm/PyCmdMessenger/issues/9) and links therein).  Behavior on OSX is currently unknown. 