### PR TITLE
Fix ArduinoBoard.write not sending the entire message

### DIFF
--- a/PyCmdMessenger/arduino.py
+++ b/PyCmdMessenger/arduino.py
@@ -184,7 +184,10 @@ class ArduinoBoard:
         Wrap serial write method.
         """
         
-        self.comm.write(msg)
+        msg_len = len(msg)
+        bytes_written = 0
+        while bytes_written < msg_len:
+            bytes_written += self.comm.write(msg[bytes_written:])
 
     def close(self):
         """


### PR DESCRIPTION
This cost me a bit of time debugging why the arduino would not receive some commands.
I'll leave it here so others won't run into the same problem.